### PR TITLE
Auto-build via github actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,40 @@
+# This workflow will upload a Python Package using Twine when a release is created
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Upload Python Package
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build
+
+    - name: Build package
+      run: python -m build
+
+    - name: Publish package
+      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(join(currdir, 'README.md')) as f:
     long_descr = f.read()
 
 setup(
-  name = "zotero-cli",
+  name = "zotero-cli-tool",
   author = "Alexandre D\'Hondt",
   author_email = "alexandre.dhondt@gmail.com",
   url = "https://github.com/dhondta/zotero-cli",

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(join(currdir, 'README.md')) as f:
     long_descr = f.read()
 
 setup(
-  name = "zotero-cli-tool",
+  name = "zotero-cli",
   author = "Alexandre D\'Hondt",
   author_email = "alexandre.dhondt@gmail.com",
   url = "https://github.com/dhondta/zotero-cli",

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
   author = "Alexandre D\'Hondt",
   author_email = "alexandre.dhondt@gmail.com",
   url = "https://github.com/dhondta/zotero-cli",
-  version = "1.2.2",
+  version = "1.3.0",
   license = "GPLv3",
   description = "Tinyscript tool for sorting and exporting Zotero references based on pyzotero",
   long_description=long_descr,


### PR DESCRIPTION
I ran into this issue:
```bash
$ zotero-cli
/usr/bin/env: ‘python\r’: No such file or directory
/usr/bin/env: use -[v]S to pass options in shebang lines
```
which is (apparently) due to the package being built and uploaded on windows. A easy fix is found here https://stackoverflow.com/questions/19425857/env-python-r-no-such-file-or-directory, however this error was reproduced in multiple `virtualenvs` on a linux machine. This PR adds an automated way to upload the package which should resolve the error.

To do this, add a repo secret called `PYPI_API_TOKEN` (which is found via [https://pypi.org/help/#apitoken](https://pypi.org/help/#apitoken)) to yout Pypi account and then create a new release.

While this (https://github.com/iwishiwasaneagle/zotero-cli/runs/4302098822?check_suite_focus=true) test run failed to publish, it only failed because I do not have write access to the `zoter-cli-tool` package. This can be seen from the highlighted log message line below. Otherwise it will have uploaded flawlessly.

```bash
Run pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
/usr/bin/docker run --name e28490122ccaafac4342ecabba4c28d5e16d82_a88dc4 --label e28490 --workdir /github/workspace --rm -e pythonLocation -e LD_LIBRARY_PATH -e INPUT_USER -e INPUT_PASSWORD -e INPUT_REPOSITORY_URL -e INPUT_PACKAGES_DIR -e INPUT_VERIFY_METADATA -e INPUT_SKIP_EXISTING -e INPUT_VERBOSE -e HOME -e GITHUB_JOB -e GITHUB_REF -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_REPOSITORY_OWNER -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RETENTION_DAYS -e GITHUB_RUN_ATTEMPT -e GITHUB_ACTOR -e GITHUB_WORKFLOW -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GITHUB_EVENT_NAME -e GITHUB_SERVER_URL -e GITHUB_API_URL -e GITHUB_GRAPHQL_URL -e GITHUB_REF_NAME -e GITHUB_REF_PROTECTED -e GITHUB_REF_TYPE -e GITHUB_WORKSPACE -e GITHUB_ACTION -e GITHUB_EVENT_PATH -e GITHUB_ACTION_REPOSITORY -e GITHUB_ACTION_REF -e GITHUB_PATH -e GITHUB_ENV -e RUNNER_OS -e RUNNER_ARCH -e RUNNER_NAME -e RUNNER_TOOL_CACHE -e RUNNER_TEMP -e RUNNER_WORKSPACE -e ACTIONS_RUNTIME_URL -e ACTIONS_RUNTIME_TOKEN -e ACTIONS_CACHE_URL -e GITHUB_ACTIONS=true -e CI=true -v "/var/run/docker.sock":"/var/run/docker.sock" -v "/home/runner/work/_temp/_github_home":"/github/home" -v "/home/runner/work/_temp/_github_workflow":"/github/workflow" -v "/home/runner/work/_temp/_runner_file_commands":"/github/file_commands" -v "/home/runner/work/zotero-cli/zotero-cli":"/github/workspace" e28490:122ccaafac4342ecabba4c28d5e16d82  "__token__" "***" "" "dist" "true" "false" "false"
Checking dist/zotero_cli_tool-1.3.0-py3-none-any.whl: PASSED
Checking dist/zotero-cli-tool-1.3.0.tar.gz: PASSED
Uploading distributions to https://upload.pypi.org/legacy/
Uploading zotero_cli_tool-1.3.0-py3-none-any.whl

  0%|          | 0.00/39.0k [00:00<?, ?B/s]
 21%|██        | 8.00k/39.0k [00:00<00:00, 61.9kB/s]
100%|██████████| 39.0k/39.0k [00:00<00:00, 120kB/s] 
Error during upload. Retry with the --verbose option for more details.
HTTPError: 403 Forbidden from https://upload.pypi.org/legacy/
THIS LINE ---> The user 'iwishiwasaneagle' isn't allowed to upload to project 'zotero-cli-tool'. See https://pypi.org/help/#project-name for more information.
```