### PR TITLE
Sync setup.py version with zotero-cli file version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
   author = "Alexandre D\'Hondt",
   author_email = "alexandre.dhondt@gmail.com",
   url = "https://github.com/dhondta/zotero-cli",
-  version = "1.4.4",
+  version = "1.5.0",
   license = "GPLv3",
   description = "Tinyscript tool for sorting and exporting Zotero references based on pyzotero",
   long_description=long_descr,


### PR DESCRIPTION
Currently there is a diff between the setup.py version and the version in zotero-cli.

I am also wondering if it would make sense to have it only defined in one area.